### PR TITLE
changes for react-hooks-fetch-data: cleaner API

### DIFF
--- a/src/useDataApiHook-example/index.js
+++ b/src/useDataApiHook-example/index.js
@@ -63,16 +63,12 @@ const useDataApi = (initialUrl, initialData) => {
     };
   }, [url]);
 
-  const doFetch = url => {
-    setUrl(url);
-  };
-
-  return { ...state, doFetch };
+  return [state, setUrl];
 };
 
 function App() {
   const [query, setQuery] = useState('redux');
-  const { data, isLoading, isError, doFetch } = useDataApi(
+  const [{data, isLoading, isError}, doFetch] = useDataApi(
     'http://hn.algolia.com/api/v1/search?query=redux',
     { hits: [] },
   );


### PR DESCRIPTION
Code changes for [issue #89 on blog_robinwieruch_content](https://github.com/rwieruch/blog_robinwieruch_content/issues/89).

Based on [this comment](https://www.robinwieruch.de/react-hooks-fetch-data/#comment-4374330989) by Matt Wright:

> You can make your fetch hook cleaner by removing 
>
> const doFetch = url => {
>   setUrl(url);
> };
>
> and just returning setUrl like so
>
> return [ ...state, setUrl ];
>
> then change your hook call to
>
> const [ data, doFetch ] = useDataApi(
> 'http://hn.algolia.com/api/v1/search?query=redux',
>   { hits: [] },
> );
>
> And now you can rename "doFetch" to anything you want```

Doing exactly as Matt Wright said yielded an error for me, so I changed it as much as I needed to.

PR for changes to blog post: https://github.com/rwieruch/blog_robinwieruch_content/pull/107